### PR TITLE
feat: Add devcontainer support with external host access

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,13 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  experimental: {
-    serverComponentsExternalPackages: [],
-  },
-  // devcontainer対応：HOSTNAME環境変数で0.0.0.0にバインド可能
-  ...(process.env.HOSTNAME && {
-    // @ts-ignore - Next.js 15の型定義に未対応の場合があるため
-    hostname: process.env.HOSTNAME,
+  serverExternalPackages: [],
+  // devcontainer support: allow binding to 0.0.0.0 via HOSTNAME environment variable
+  ...(process.env["HOSTNAME"] && {
+    // @ts-ignore - Next.js 15 type definitions may not support this yet
+    hostname: process.env["HOSTNAME"],
   }),
 };
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  experimental: {
+    serverComponentsExternalPackages: [],
+  },
+  // devcontainer対応：HOSTNAME環境変数で0.0.0.0にバインド可能
+  ...(process.env.HOSTNAME && {
+    // @ts-ignore - Next.js 15の型定義に未対応の場合があるため
+    hostname: process.env.HOSTNAME,
+  }),
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "dev": "run-p 'dev:*'",
-    "dev:next": "PORT=3400 next dev --turbopack",
+    "dev:next": "PORT=3400 next dev --turbopack ${HOSTNAME:+--hostname $HOSTNAME}",
     "start": "node dist/index.js",
     "build": "./scripts/build.sh",
     "lint": "run-s 'lint:*'",


### PR DESCRIPTION
## Summary
- Add HOSTNAME environment variable support for binding to 0.0.0.0 in devcontainer environments
- Enable external host access for both development and production servers
- Fix Next.js 15 compatibility issues and TypeScript errors

## Changes
- Update `next.config.ts` to accept hostname configuration via HOSTNAME environment variable
- Modify `dev:next` script to support hostname option dynamically
- Move `serverComponentsExternalPackages` to `serverExternalPackages` for Next.js 15 compatibility
- Fix TypeScript access pattern for environment variables
- Convert comments to English for consistency

## Use Cases
This enables the application to be accessible from the host machine when running in devcontainer environments, which is essential for:
- Remote development workflows
- Docker-based development environments
- Testing on different devices/browsers on the same network

## Usage
**Development server:**
```bash
HOSTNAME=0.0.0.0 pnpm dev
```

**Production server:**
```bash
HOSTNAME=0.0.0.0 PORT=3400 pnpm start
```

## Test Plan
- [x] Verify development server starts with external access
- [x] Verify production server starts with external access  
- [x] Confirm Next.js build completes without errors
- [x] Test TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.ai/code)